### PR TITLE
Update draft-krishnan-iab-rfc4052bis.md

### DIFF
--- a/draft-krishnan-iab-rfc4052bis.md
+++ b/draft-krishnan-iab-rfc4052bis.md
@@ -74,8 +74,8 @@ The management of other organizations' liaison managers to the IETF,
 whether or not in the context of a liaison relationship, is outside
 the scope of this document.
 
-The IETF has chartered the Internet Architecture Board to manage
-the formal liaison relationships.  Consistent with its charter {{!BCP39}},
+The IETF has tasked the Internet Architecture Board to manage
+formal liaison relationships.  Consistent with its charter {{!BCP39}},
 the IAB acts as representative of the interests of the IETF
 in technical liaison relationships with other organizations
 concerned with standards, and other technical and organizational


### PR DESCRIPTION
I appreciate this sentence was carried over from the original RFC.  However, re-reading the sentence a lifetime later, it struck me that it sounds like 1/ the IETF chartered the IAB (solely) and 2/ this is the IAB's only purpose.