### PR TITLE
Remove redundancy in liaison manager section

### DIFF
--- a/draft-krishnan-iab-rfc4052bis.md
+++ b/draft-krishnan-iab-rfc4052bis.md
@@ -240,7 +240,7 @@ input discussion in specific working group in the IETF.
 ## Liaison Manager Responsibilities {#manager}
 
 The main responsibility of the liaison manager is to ensure good, formally
-correct, productive, and timely (formal and informal) communication between the organizations. 
+correct, productive, and timely (formal and informal) communication between the organizations.
 This often includes:
 
 - Ensure received liaison statements are recorded and delivered to the relevant groups.


### PR DESCRIPTION
I noticed that I copied the "summary of liaison manager responsibilities" section in the wrong place. This PR merged it with the existing section and removes redundant text. There is still some redundancy with the liaison communication section, but maybe we can clear that up in a separate PR.