### PR TITLE
The existence of a manager establishes a liaison

### DIFF
--- a/draft-iab-rfc4052bis.md
+++ b/draft-iab-rfc4052bis.md
@@ -142,8 +142,7 @@ This version of the document contains the following updates:
 
 # Establishing Formal Liaison Relationships {#relationship}
 
-The IAB appoints a liaison manager to establish a formal liaison relationship between the IETF and
-another organization when it is mutually agreeable and beneficial to do so.
+Once the IAB and the other organization mutually agree that a formal liaison relationship is beneficial, the IAB appoints a liaison manager to establish it.
 
 Generally informal collaboration between the IETF and peer
 organizations is preferred whenever direct working


### PR DESCRIPTION
This small changes clarifies that the only formal process to establish a "formal liaison relationship" is the appointment of a liaison manager. This is already explain like this in the introduction and this change aligns the text better.