### PR TITLE
reorg section on "speaking for the IETF"

### DIFF
--- a/draft-iab-rfc4052bis.md
+++ b/draft-iab-rfc4052bis.md
@@ -246,12 +246,9 @@ This often includes:
   material information that is intended to be shared by the peer organization.
 
 Formal messages from the IETF to the peer organization are usually carried in liaison
-statements. In certain situations, the liaison manager may carry additional messages for
-providing further context. However, if these communications aim to "represent the IETF",
-they must have consensus, e.g. by being based on an RFC or some other formal statement
-by a group within the IETF. For such additional communication, liaison managers
-may use any applicable businesslike approach, from
-private to public communications, and bring in other parties as needed.
+statements. The liaison manager must not send liaison statements on their own initiative to a
+liaised organization on behalf of IETF, or any of its areas and
+working groups.
 
 IETF liaison managers should also communicate and coordinate with
 other liaison managers where concerned technical activities overlap.
@@ -263,13 +260,18 @@ manager needs to have a complete overview of everything that is going on there.
 
 ## Speaking for the IETF
 
-The mandate for IETF liaison managers is strictly limited to
-conveying IETF consensus to the liaised organization.  The liaison
-manager must not send liaison statements on their own initiative to a
-liaised organization on behalf of IETF, or any of its areas and
-working groups. The liaison manager speaks on behalf of the IETF on
+In certain situations, the liaison manager may carry additional messages for
+providing further context. For such additional communication, liaison managers
+may use any applicable businesslike approach, from
+private to public communications, and bring in other parties as needed.
+However, the mandate for IETF liaison managers is strictly limited to
+conveying IETF consensus to the liaised organization.
+The liaison manager speaks on behalf of the IETF on
 the subject matter of the liaison, but only after making sure that
-the IETF consensus is understood.
+the IETF consensus is understood. Specifically,
+if these communications aim to "represent the IETF",
+they must have consensus, e.g. by being based on an RFC or some other formal statement
+by a group within the IETF.
 
 # Security Considerations
 


### PR DESCRIPTION
by merging parts of the former paragraph into this subsection.

This is an alternative to PR #60 in case we want to keep the subsection.